### PR TITLE
Pin espressif32 version to prevent Arduino Core upgrade

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ board_build.f_flash = 80000000L
 ;build_flags = -DENABLE_DEBUG 
 
 [env:esp32_sprinkler]
-platform = espressif32
+platform = espressif32@6.11.0
 board = bpi-bit
 framework = arduino
 lib_ldf_mode = deep


### PR DESCRIPTION
Builds brake on latest PlatformIO / platform-espressif32 ≥ 7.0 as it bumped the default tool-chain to GCC 12, switched the Arduino-ESP32 core to v3.x, and enlarged a lot of IDF 5.1 libraries. This firmware now links to ~1.42 MB, and pio `checkprogsize` throws:

```
Program size (1424913 bytes) is greater than maximum allowed (1310720 bytes)
```

Version 6.11.0 is the last release on the 6-series (Arduino-ESP32 2.0.17, IDF 4.4). It keeps the binary comfortably under the 1 310 720-byte ceiling that the stock `default.csv` partition table enforces, with zero code changes required.

Long term it would be great to migrate to Arduino-ESP32 3.x and adopt a larger partition table (e.g. `min_spiffs.csv`) as we miss out on the new IDF 5.1 drivers and Wi-Fi fixes.